### PR TITLE
Fixing a bug with phrase extractor

### DIFF
--- a/metrics/litter.py
+++ b/metrics/litter.py
@@ -569,6 +569,9 @@ if __name__ == '__main__':
         for i, (src_line, ref_line, hyp_line, sp_line) \
                 in enumerate(zip(fsrc, fref, fhyp, fspan)):
 
+            if sp_line.strip() == "":
+                continue
+
             logging.info("\n")
 
             label, span = sp_line.split("\t")

--- a/phrase_extractor/phrase_extractor.py
+++ b/phrase_extractor/phrase_extractor.py
@@ -224,7 +224,7 @@ def main(cfg, viz=True):
                 f.write("\n")
         elif cfg.line_aligned:
             with open(sent_file, "a") as f:
-                f.write("\n")
+                f.write(text + "\n")
 
             with open(span_file, "a") as f:
                 f.write("\n")

--- a/phrase_extractor/phrase_extractor.py
+++ b/phrase_extractor/phrase_extractor.py
@@ -158,7 +158,7 @@ def get_matcher(phrase_file, nlp):
     return matcher
 
 
-def get_miner(nlp, matcher, doc_file):
+def get_miner(nlp, matcher, doc_file, line_aligned=False):
     """
     Return sentences that contain at least one match
     """
@@ -177,15 +177,17 @@ def get_miner(nlp, matcher, doc_file):
     iterator = tqdm(pipeline, total=num_lines, desc=get_desc())
     for i, doc in enumerate(iterator):
         matches = doc._.matches
-        num_matches += 1
-        iterator.set_description(get_desc())
-        yield i, doc, matches
+        if len(matches) > 0:
+            num_matches += 1
+            iterator.set_description(get_desc())
+        if line_aligned or len(matches) > 0:
+            yield i, doc, matches
 
 
 def main(cfg, viz=True):
     nlp = get_nlp_model(cfg.lang, cfg.model_size)
     matcher = get_matcher(cfg.phrases, nlp)
-    miner = get_miner(nlp, matcher, cfg.corpus)
+    miner = get_miner(nlp, matcher, cfg.corpus, cfg.line_aligned)
     stats = collections.OrderedDict((nlp.vocab.strings[p], 0)
                                     for p in matcher._patterns)
 

--- a/phrase_extractor/phrase_extractor.py
+++ b/phrase_extractor/phrase_extractor.py
@@ -177,10 +177,9 @@ def get_miner(nlp, matcher, doc_file):
     iterator = tqdm(pipeline, total=num_lines, desc=get_desc())
     for i, doc in enumerate(iterator):
         matches = doc._.matches
-        if len(matches) > 0:
-            num_matches += 1
-            iterator.set_description(get_desc())
-            yield i, doc, matches
+        num_matches += 1
+        iterator.set_description(get_desc())
+        yield i, doc, matches
 
 
 def main(cfg, viz=True):
@@ -222,6 +221,15 @@ def main(cfg, viz=True):
 
             with open(annot_file, "a") as f:
                 f.write("\t".join([str(line_id), name, str(spans), text]))
+                f.write("\n")
+        elif cfg.line_aligned:
+            with open(sent_file, "a") as f:
+                f.write("\n")
+
+            with open(span_file, "a") as f:
+                f.write("\n")
+
+            with open(annot_file, "a") as f:
                 f.write("\n")
 
     logging.info(f"Finished!")
@@ -268,6 +276,9 @@ if __name__ == '__main__':
                              'therefore `sm` offers the best trade-off.')
     parser.add_argument('--min-length',
                         help='The minimum number of words for keeping a sentence.')
+    parser.add_argument('--line-aligned', action='store_true', default=False,
+                        help='Output an empty line when there is no match found for the sentence, '
+                             'so all output files remain line-aligned with the input.')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Under the current implementation, in the case of a failed extraction, we will get a span file that is misaligned with the input sentences. Passing those misaligned files to `litter.py` will cause the wrong span to be extracted, thus affecting the calculated LitTER score.

This PR proposes to fix this issue by adding an 'line-aligned' option that will output files that are line-aligned with the original input file, inserting empty lines in the case of failed extraction. When encountering those empty lines, `litter.py` should just skip them because neither the number of labels or the number of errors is updated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.